### PR TITLE
Make on screen keyboard to appear

### DIFF
--- a/lib/parchment.debug.js
+++ b/lib/parchment.debug.js
@@ -512,7 +512,8 @@ TextInput = Object.subClass({
 			.width( 20 )
 			.val( '' )
 			.appendTo( prompt )
-			.width( order.target.offset().left + order.target.width() - input.offset().left );
+			.width( order.target.offset().left + order.target.width() - input.offset().left )
+			.focus(); //this should make on screen keyboards to pop up in touch devices
 		
 		this.scroll();
 	},


### PR DESCRIPTION
Makes life easier with touch screen devices making keyboard to pop up.
Even thou on Ubuntu Phone the keyboard doesn't show at the start of the story (on the first load) even the input is on focus (and cursor blinking). A bug of Ubuntu Touch?